### PR TITLE
Add nginx reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ scraper/.DS_Store
 # playwright
 playwright-report
 test-results
+
+docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,16 +21,30 @@ services:
       "
     restart: 'no'
 
+  nginx: 
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - web
+    networks:
+      - app-network
+    restart: unless-stopped
+
   web:
     image: ghcr.io/62595-fullstack-gruppe-placeholder/reporacoon/web:latest
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+    pull_policy: always # always pull fresh images for deployment. overridden locally
     environment:
       DATABASE_URL: postgresql://root:fisk@postgres:5432/reporacoondb?sslmode=disable
       NEXT_TELEMETRY_DISABLED: 1
       JWT_PRIVATE_KEY_PATH: /keys/private_key.pem
       JWT_PUBLIC_KEY_PATH: /keys/public_key.pem
-      NEXT_PUBLIC_APP_URL: http://localhost:3000 #should prolly change on server
-    ports:
-      - "3000:3000"
+      NEXT_PUBLIC_APP_URL: http://localhost #should prolly change on server
     volumes:
       - jwt-keys:/keys:ro # mount RSA keys as read only
     depends_on:
@@ -45,6 +59,10 @@ services:
 
   scraper:
     image: ghcr.io/62595-fullstack-gruppe-placeholder/reporacoon/scraper:latest
+    build:
+      context: ./scraper
+      dockerfile: Dockerfile
+    pull_policy: always # always pull fresh images for deployment. overridden locally
     environment:
       DATABASE_URL: postgresql://root:fisk@postgres:5432/reporacoondb?sslmode=disable
     ports:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,49 @@
+server {
+    listen 80;
+    server_name localhost;  # Update to your domain later
+
+    # Security basics
+    server_tokens off;
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/json
+        application/javascript
+        application/xml+rss
+        application/atom+xml
+        image/svg+xml;
+
+    # Timeout settings
+    client_max_body_size 10M;
+    client_body_timeout 12s;
+    send_timeout 10s;
+
+    location / {
+        proxy_pass http://web:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Next.js static files (cacheable)
+        location ~ ^/_next/static/ {
+            proxy_cache_valid 200 30d;
+            proxy_pass http://web:3000;
+            add_header Cache-Control "public, max-age=2592000, immutable";
+        }
+    }
+}


### PR DESCRIPTION
Added an nginx reverse proxy, which routes traffic from the default http port to our internal web service port, eliminating the need for specifying port 3000 in development (you can just put `localhost`) and in production. This also allows caching and enables us to easily add an encryption connection later.